### PR TITLE
Agregar explorador de impacto raqueta‑bola y modelado de impacto

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Table Tennis Physics Simulator is an innovative and educational project that
 ## Key Features
 
 - **Realistic Physics:** Immerse yourself in an authentic table tennis experience with accurate simulations of ball trajectories influenced by drag, Magnus force, and table friction.
-- **Interactive Interface:** Easily customize parameters such as ball speed, spin, and angle to observe their profound effects on the ball's path.
+- **Interactive Interface:** Easily customize parameters such as ball speed, spin, racket angle, rubber friction, rubber restitution, and racket velocity to observe their effects on the ball's path.
 - **Visual Delight:** Watch the action unfold through captivating visualizations that vividly depict the intricate interplay between physics and sports.
 - **Educational Tool:** Gain a deeper understanding of physics concepts by witnessing their direct impact on a familiar and engaging scenario.
 
@@ -19,7 +19,7 @@ The Table Tennis Physics Simulator is an innovative and educational project that
 
 1. **Clone the Repository:** Start by cloning this repository to your local machine using `git clone https://github.com/dyanguasr/table-tennis-physics.git`.
 
-2. **Run the Simulator:** Launch the MATLAB version with `TableTennisTests.mlx`, run the Python script with `python table_tennis_simulation.py [--save output.mp4]`, or open `interactive_table_tennis.ipynb` to experiment with sliders.
+2. **Run the Simulator:** Launch the MATLAB version with `TableTennisTests.mlx`, run the Python script with `python table_tennis_simulation.py [--save output.mp4]`, open `interactive_table_tennis.ipynb` to experiment with sliders, or open `racket_impact_explorer.ipynb` to explore racket-impact parameters and coaching moments 1-6.
 
 3. **Experiment and Explore:** Tweak the parameters, observe the changes in ball trajectories, and marvel at the elegance of physics at play.
 

--- a/racket_impact_explorer.ipynb
+++ b/racket_impact_explorer.ipynb
@@ -1,0 +1,121 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Explorador interactivo de impacto raqueta-bola\n",
+        "\n",
+        "Este cuaderno usa `table_tennis_simulation.py` para variar parámetros del golpe con sliders, simular la trayectoria resultante e identificar los momentos 1-6 de entrenamiento."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "from ipywidgets import interact, FloatSlider\n",
+        "\n",
+        "from table_tennis_simulation import (\n",
+        "    RacketImpactParameters, TABLE_HEIGHT, BALL_RADIUS, TABLE_LENGTH, TABLE_WIDTH,\n",
+        "    simulate_racket_impact, identify_trajectory_moments, draw_racket, plot_table\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def summarize_moments(moments):\n",
+        "    for number, moment in moments.items():\n",
+        "        interval = f\", intervalo={moment.interval}, punto medio={np.round(moment.midpoint, 1)}\" if moment.interval else \"\"\n",
+        "        print(f\"Momento {number}: {moment.name}; t={moment.time:.3f}s; punto={np.round(moment.point, 1)}{interval}\")\n",
+        "\n",
+        "\n",
+        "def explore(ball_vx=-2000, ball_vy=0, ball_vz=-1000,\n",
+        "            omega_x=0, omega_y=0, omega_z=471,\n",
+        "            friction=0.60, restitution=0.85,\n",
+        "            angle_x=0, angle_y=-30, angle_z=0,\n",
+        "            racket_vx=2000, racket_vy=0, racket_vz=1000):\n",
+        "    params = RacketImpactParameters(\n",
+        "        ball_velocity=(ball_vx, ball_vy, ball_vz),\n",
+        "        ball_omega=(omega_x, omega_y, omega_z),\n",
+        "        rubber_friction=friction,\n",
+        "        rubber_restitution=restitution,\n",
+        "        racket_angle=(angle_x, angle_y, angle_z),\n",
+        "        racket_velocity=(racket_vx, racket_vy, racket_vz),\n",
+        "    )\n",
+        "    result = simulate_racket_impact(params, dt=0.005, t_max=2.0)\n",
+        "    moments = identify_trajectory_moments(result)\n",
+        "\n",
+        "    fig = plt.figure(figsize=(12, 5))\n",
+        "    ax = fig.add_subplot(121, projection='3d')\n",
+        "    ax.plot(result.x[0], result.x[1], result.x[2], color='purple')\n",
+        "    draw_racket(ax, center=params.ball_position, angle=params.racket_angle)\n",
+        "    ax.set_xlim(-200, TABLE_LENGTH + 600)\n",
+        "    ax.set_ylim(-300, TABLE_WIDTH + 300)\n",
+        "    ax.set_zlim(0, 1800)\n",
+        "    ax.set_xlabel('X (mm)')\n",
+        "    ax.set_ylabel('Y (mm)')\n",
+        "    ax.set_zlabel('Z (mm)')\n",
+        "    ax.set_title('Trayectoria y raqueta')\n",
+        "\n",
+        "    ax2 = fig.add_subplot(122)\n",
+        "    t = result.t\n",
+        "    ax2.plot(t, result.x[2], label='altura bola')\n",
+        "    ax2.axhline(TABLE_HEIGHT + BALL_RADIUS, color='tab:gray', linestyle='--', label='nivel mesa + radio')\n",
+        "    for number, moment in moments.items():\n",
+        "        ax2.scatter(moment.time, moment.point[2], label=f'M{number}')\n",
+        "    ax2.set_xlabel('Tiempo (s)')\n",
+        "    ax2.set_ylabel('Z (mm)')\n",
+        "    ax2.legend()\n",
+        "    plt.tight_layout()\n",
+        "    summarize_moments(moments)\n",
+        "    return result, moments\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "interact(\n",
+        "    explore,\n",
+        "    ball_vx=FloatSlider(value=-2000, min=-12000, max=12000, step=250, description='Bola Vx'),\n",
+        "    ball_vy=FloatSlider(value=0, min=-8000, max=8000, step=250, description='Bola Vy'),\n",
+        "    ball_vz=FloatSlider(value=-1000, min=-8000, max=8000, step=250, description='Bola Vz'),\n",
+        "    omega_x=FloatSlider(value=0, min=-1000, max=1000, step=25, description='Ωx'),\n",
+        "    omega_y=FloatSlider(value=0, min=-1000, max=1000, step=25, description='Ωy'),\n",
+        "    omega_z=FloatSlider(value=471, min=-1500, max=1500, step=25, description='Ωz'),\n",
+        "    friction=FloatSlider(value=0.60, min=0, max=1.5, step=0.05, description='Fricción'),\n",
+        "    restitution=FloatSlider(value=0.85, min=0, max=1.2, step=0.05, description='Restitución'),\n",
+        "    angle_x=FloatSlider(value=0, min=-90, max=90, step=2.5, description='Ángulo X'),\n",
+        "    angle_y=FloatSlider(value=-30, min=-90, max=90, step=2.5, description='Ángulo Y'),\n",
+        "    angle_z=FloatSlider(value=0, min=-180, max=180, step=5, description='Ángulo Z'),\n",
+        "    racket_vx=FloatSlider(value=2000, min=-8000, max=12000, step=250, description='Raqueta Vx'),\n",
+        "    racket_vy=FloatSlider(value=0, min=-8000, max=8000, step=250, description='Raqueta Vy'),\n",
+        "    racket_vz=FloatSlider(value=1000, min=-8000, max=8000, step=250, description='Raqueta Vz'),\n",
+        ");\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/table_tennis_simulation.py
+++ b/table_tennis_simulation.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -57,6 +57,35 @@ class SimulationResult:
     theta: np.ndarray
     omega: np.ndarray
     alpha: np.ndarray
+    t: Optional[np.ndarray] = None
+
+
+@dataclass
+class RacketImpactParameters:
+    """Input parameters for a ball-racket impact model.
+
+    Units match the rest of the module: millimetres, seconds and radians.
+    The racket angle is measured in degrees around X, Y and Z and rotates the
+    default racket normal (+X).
+    """
+
+    ball_velocity: Tuple[float, float, float] = (-2000.0, 0.0, -1000.0)
+    ball_omega: Tuple[float, float, float] = (0.0, 0.0, 75.0 * 2 * np.pi)
+    rubber_friction: float = 0.6
+    rubber_restitution: float = 0.85
+    racket_angle: Tuple[float, float, float] = (0.0, -30.0, 0.0)
+    racket_velocity: Tuple[float, float, float] = (2000.0, 0.0, 1000.0)
+    ball_position: Tuple[float, float, float] = (200.0, TABLE_WIDTH / 2, TABLE_HEIGHT + 240.0)
+
+
+@dataclass
+class TrajectoryMoment:
+    name: str
+    index: int
+    time: float
+    point: Tuple[float, float, float]
+    interval: Optional[Tuple[float, float]] = None
+    midpoint: Optional[Tuple[float, float, float]] = None
 
 
 def simulate(ic: InitialConditions, dt: float = DT, t_max: float = T_MAX) -> SimulationResult:
@@ -118,7 +147,144 @@ def simulate(ic: InitialConditions, dt: float = DT, t_max: float = T_MAX) -> Sim
             omega[:, k] = NET_RESTITUTION * omega[:, k]
             v[0, k] = -NET_RESTITUTION * v[0, k]
 
-    return SimulationResult(x, v, a, theta, omega, alpha)
+    return SimulationResult(x, v, a, theta, omega, alpha, t)
+
+
+def _rotation_matrix_xyz(angles_deg: Tuple[float, float, float]) -> np.ndarray:
+    """Return the XYZ Euler rotation matrix for degrees."""
+
+    ax, ay, az = np.deg2rad(angles_deg)
+    rx = np.array([[1, 0, 0], [0, np.cos(ax), -np.sin(ax)], [0, np.sin(ax), np.cos(ax)]])
+    ry = np.array([[np.cos(ay), 0, np.sin(ay)], [0, 1, 0], [-np.sin(ay), 0, np.cos(ay)]])
+    rz = np.array([[np.cos(az), -np.sin(az), 0], [np.sin(az), np.cos(az), 0], [0, 0, 1]])
+    return rz @ ry @ rx
+
+
+def racket_normal(racket_angle: Tuple[float, float, float]) -> np.ndarray:
+    """Compute the unit normal of the racket face from its angle."""
+
+    normal = _rotation_matrix_xyz(racket_angle) @ np.array([1.0, 0.0, 0.0])
+    return normal / np.linalg.norm(normal)
+
+
+def apply_racket_impact(params: RacketImpactParameters) -> InitialConditions:
+    """Compute post-impact ball initial conditions for a racket strike.
+
+    The model resolves relative ball/racket velocity into normal and tangent
+    components. Restitution controls the normal rebound; friction couples
+    tangential slip with spin at the contact patch.
+    """
+
+    ball_v = np.array(params.ball_velocity, dtype=float)
+    ball_w = np.array(params.ball_omega, dtype=float)
+    racket_v = np.array(params.racket_velocity, dtype=float)
+    normal = racket_normal(params.racket_angle)
+
+    relative_v = ball_v - racket_v
+    normal_speed = np.dot(relative_v, normal)
+    relative_normal = normal_speed * normal
+    relative_tangent = relative_v - relative_normal
+
+    restitution = np.clip(params.rubber_restitution, 0.0, 1.5)
+    friction = np.clip(params.rubber_friction, 0.0, 2.0)
+    post_relative_v = relative_tangent * max(0.0, 1.0 - friction) - restitution * relative_normal
+    post_v = racket_v + post_relative_v
+
+    contact_radius = -BALL_RADIUS * normal
+    surface_slip = relative_tangent + np.cross(ball_w, contact_radius)
+    post_w = ball_w - friction * np.cross(contact_radius, surface_slip) / (BALL_RADIUS**2)
+
+    return InitialConditions(pos=params.ball_position, vel=tuple(post_v), omega=tuple(post_w))
+
+
+def simulate_racket_impact(params: RacketImpactParameters, dt: float = DT, t_max: float = T_MAX) -> SimulationResult:
+    """Apply a racket impact and simulate the resulting trajectory."""
+
+    return simulate(apply_racket_impact(params), dt=dt, t_max=t_max)
+
+
+def identify_trajectory_moments(result: SimulationResult, table_level: float = TABLE_HEIGHT + BALL_RADIUS) -> Dict[int, TrajectoryMoment]:
+    """Identify coaching moments 1-6 along a simulated trajectory.
+
+    Moment 1 is the first table bounce on the opposite half; 2 is the rising
+    interval after that bounce (including its midpoint); 3 is the apex; 4 is the
+    descending interval above the table; 5 is the second arrival at table level;
+    6 is the first sample below table level after moment 5, when present.
+    """
+
+    t = result.t if result.t is not None else np.arange(result.x.shape[1]) * DT
+    x, z, vz = result.x[0], result.x[2], result.v[2]
+    moments: Dict[int, TrajectoryMoment] = {}
+
+    bounce_candidates = np.where((x >= TABLE_LENGTH / 2) & (np.isclose(z, table_level, atol=1e-6)) & (vz > 0))[0]
+    if bounce_candidates.size == 0:
+        bounce_candidates = np.where((x >= TABLE_LENGTH / 2) & (z <= table_level) & (vz > 0))[0]
+    if bounce_candidates.size == 0:
+        return moments
+
+    i1 = int(bounce_candidates[0])
+    moments[1] = TrajectoryMoment("primer impacto en el lado contrario", i1, float(t[i1]), tuple(result.x[:, i1]))
+
+    post = np.arange(i1, result.x.shape[1])
+    rising = post[vz[post] > 0]
+    if rising.size:
+        r0, r1 = int(rising[0]), int(rising[-1])
+        mid_i = int(round((r0 + r1) / 2))
+        moments[2] = TrajectoryMoment("fase ascendente", mid_i, float(t[mid_i]), tuple(result.x[:, mid_i]), (float(t[r0]), float(t[r1])), tuple(result.x[:, mid_i]))
+
+    apex_i = int(post[np.argmax(z[post])])
+    moments[3] = TrajectoryMoment("punto más alto", apex_i, float(t[apex_i]), tuple(result.x[:, apex_i]))
+
+    descending = post[(post > apex_i) & (z[post] >= table_level)]
+    if descending.size:
+        d0, d1 = int(descending[0]), int(descending[-1])
+        mid_i = int(round((d0 + d1) / 2))
+        moments[4] = TrajectoryMoment("fase descendente sobre la mesa", mid_i, float(t[mid_i]), tuple(result.x[:, mid_i]), (float(t[d0]), float(t[d1])), tuple(result.x[:, mid_i]))
+
+    arrivals = post[(post > apex_i) & (z[post] <= table_level)]
+    if arrivals.size:
+        i5 = int(arrivals[0])
+        moments[5] = TrajectoryMoment("segunda llegada al nivel de la mesa", i5, float(t[i5]), tuple(result.x[:, i5]))
+        below = post[(post > i5) & (z[post] < table_level)]
+        if below.size:
+            i6 = int(below[0])
+            moments[6] = TrajectoryMoment("bola por debajo del nivel de la mesa", i6, float(t[i6]), tuple(result.x[:, i6]))
+
+    return moments
+
+
+def _elliptic_cylinder(center, radius_y, radius_z, thickness, rotation, resolution=32):
+    """Create an elliptic cylinder mesh with local thickness along X."""
+
+    u = np.linspace(0, 2 * np.pi, resolution)
+    xs = np.array([-thickness / 2, thickness / 2])
+    X, U = np.meshgrid(xs, u)
+    local = np.stack([X, radius_y * np.cos(U), radius_z * np.sin(U)], axis=0).reshape(3, -1)
+    world = (rotation @ local).reshape(3, *X.shape) + np.array(center).reshape(3, 1, 1)
+    return world[0], world[1], world[2]
+
+
+def draw_racket(ax: plt.Axes, center=(0, 0, 0), angle=(0, 0, 0)) -> None:
+    """Draw a standard racket as five elliptic blade layers plus a handle."""
+
+    rotation = _rotation_matrix_xyz(angle)
+    layers = [
+        ("black", 2.0),
+        ("#f0c060", 2.2),
+        ("#deb887", 6.0),
+        ("#f0c060", 2.2),
+        ("red", 2.0),
+    ]
+    offset = -sum(width for _, width in layers) / 2
+    for color, width in layers:
+        layer_center = np.array(center) + rotation @ np.array([offset + width / 2, 0.0, 0.0])
+        X, Y, Z = _elliptic_cylinder(layer_center, 75.0, 80.0, width, rotation)
+        ax.plot_surface(X, Y, Z, color=color, alpha=0.9, edgecolor="none")
+        offset += width
+
+    handle_center = np.array(center) + rotation @ np.array([0.0, -120.0, 0.0])
+    X, Y, Z = _elliptic_cylinder(handle_center, 25.0, 18.0, 95.0, rotation @ _rotation_matrix_xyz((0.0, 0.0, 90.0)))
+    ax.plot_surface(X, Y, Z, color="#8b5a2b", alpha=0.95, edgecolor="none")
 
 
 def plot_table(ax: plt.Axes, pos, vel, acc, orient, ang_vel, ang_acc, yaw, pitch) -> None:
@@ -166,6 +332,7 @@ def plot_table(ax: plt.Axes, pos, vel, acc, orient, ang_vel, ang_acc, yaw, pitch
     ax.quiver(pos[0], pos[1], pos[2], vel[0], vel[1], vel[2], length=10 / 98, color="g")
     ax.quiver(pos[0], pos[1], pos[2], acc[0], acc[1], acc[2], length=1 / 49, color="c")
     ax.quiver(pos[0], pos[1], pos[2], ang_vel[0], ang_vel[1], ang_vel[2], length=1, color="r")
+    draw_racket(ax, center=(120.0, TABLE_WIDTH * 5 / 8, TABLE_HEIGHT + 300.0), angle=(0.0, -10.0, 0.0))
 
     ax.view_init(pitch, yaw)
     ax.set_xlabel("X (mm)")


### PR DESCRIPTION
### Motivation
- Añadir soporte para modelar el impacto raqueta‑bola con parámetros configurables (velocidad lineal/angular de la bola, fricción y restitución del caucho, ángulo y velocidad de la raqueta) para poder explorar su efecto en la trayectoria. 
- Proveer identificación automática de los «momentos» de entrenamiento (1–6) en la trayectoria para facilitar análisis y visualización en un cuaderno interactivo. 

### Description
- Se añadió la dataclass `RacketImpactParameters` con campos para `ball_velocity`, `ball_omega`, `rubber_friction`, `rubber_restitution`, `racket_angle`, `racket_velocity` y `ball_position` en `table_tennis_simulation.py`. 
- Se extendió `SimulationResult` con el vector de tiempo `t` y se implementaron las funciones `apply_racket_impact`, `simulate_racket_impact`, `_rotation_matrix_xyz` y `racket_normal` para calcular las condiciones iniciales post‑impacto a partir de los parámetros de la raqueta. 
- Se implementó `identify_trajectory_moments` que detecta los momentos 1–6 (incluyendo intervalos y punto medio para las fases ascendentes/descendentes cuando aplican) y la estructura `TrajectoryMoment` para describir cada momento. 
- Se añadió renderizado de la raqueta como capas de cilindros elípticos (`_elliptic_cylinder` y `draw_racket`) y se integró su dibujo en la visualización existente; además se creó el cuaderno interactivo `racket_impact_explorer.ipynb` con sliders para todos los parámetros solicitados y visualización de la trayectoria y momentos. 
- Se actualizó `README.md` para mencionar el nuevo cuaderno y los parámetros interactivos disponibles. 

### Testing
- Se compiló el módulo con `python -m py_compile table_tennis_simulation.py` y la comprobación de sintaxis pasó correctamente. 
- Se validó el JSON del cuaderno con `python -m json.tool racket_impact_explorer.ipynb >/dev/null` y la comprobación pasó correctamente. 
- Se ejecutó una prueba funcional que crea `RacketImpactParameters`, corre `simulate_racket_impact(...)` y verifica que `identify_trajectory_moments(...)` devuelve los momentos `[1,2,3,4,5,6]` y que el `moments[2]` incluye `interval` y `midpoint`, y la prueba pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39b14d69988333868413dad98e4272)