### PR TITLE
Tune direct serve spin and table bounce

### DIFF
--- a/benchmark_direct_services.py
+++ b/benchmark_direct_services.py
@@ -27,35 +27,40 @@ from table_tennis_simulation import (
     simulate,
 )
 
+RPS = 2 * np.pi
+
+# Direct-service angular velocities are expressed as revolutions per second
+# times RPS.  The benchmark intentionally uses 50-100 rps of combined spin so
+# Magnus lift/sideswerve are visible instead of near-dead-ball trajectories.
 SERVICE_TYPES = {
     "pendulum": {
         "position": (120.0, TABLE_WIDTH * 0.28, TABLE_HEIGHT + 310.0),
-        "omega": (1.6, -4.2, 10.4),
+        "omega": (0.0, -45.0 * RPS, -35.0 * RPS),
         "velocity_adjust": (80.0, 0.0, -20.0),
     },
     "reverse_pendulum": {
         "position": (120.0, TABLE_WIDTH * 0.50, TABLE_HEIGHT + 310.0),
-        "omega": (-1.6, 4.2, -10.4),
+        "omega": (0.0, -45.0 * RPS, 35.0 * RPS),
         "velocity_adjust": (-40.0, 0.0, 20.0),
     },
     "hook": {
         "position": (110.0, TABLE_WIDTH * 0.24, TABLE_HEIGHT + 300.0),
-        "omega": (0.8, -6.4, 13.6),
+        "omega": (0.0, -50.0 * RPS, -45.0 * RPS),
         "velocity_adjust": (200.0, 0.0, 0.0),
     },
     "tomahawk": {
         "position": (120.0, TABLE_WIDTH * 0.74, TABLE_HEIGHT + 315.0),
-        "omega": (10.4, 2.4, -4.8),
+        "omega": (50.0 * RPS, -30.0 * RPS, 0.0),
         "velocity_adjust": (60.0, 0.0, -10.0),
     },
     "reverse_tomahawk": {
         "position": (120.0, TABLE_WIDTH * 0.55, TABLE_HEIGHT + 315.0),
-        "omega": (-10.4, -2.4, 4.8),
+        "omega": (-50.0 * RPS, -30.0 * RPS, 0.0),
         "velocity_adjust": (40.0, 0.0, 0.0),
     },
     "backhand_standard": {
         "position": (130.0, TABLE_WIDTH * 0.50, TABLE_HEIGHT + 305.0),
-        "omega": (-3.6, -1.8, 8.8),
+        "omega": (0.0, -40.0 * RPS, 35.0 * RPS),
         "depth_velocity": {
             "short": (4400.0, 0.0, -2390.0),
             "two_bounce": (5800.0, 0.0, -1755.0),

--- a/table_tennis_simulation.py
+++ b/table_tennis_simulation.py
@@ -20,7 +20,7 @@ import numpy as np
 BALL_MASS = 2.7  # g
 BALL_RADIUS = 20.25  # mm
 BALL_ROT_INERTIA = 2 / 3 * BALL_MASS * BALL_RADIUS**2
-TABLE_RESTITUTION = 0.77
+TABLE_RESTITUTION = 0.89
 NET_RESTITUTION = 0.5
 DRAG = 2.7  # mN/(mm/s)
 ROT_DRAG = 350.0  # mN mm/[rad/s]


### PR DESCRIPTION
### Motivation
- Make table bounces livelier by increasing the table restitution and ensure the direct-service benchmark uses realistic, non-dead spins so Magnus lift/sideswerve is visible (benchmark targets ~50–100 rps combined spin). 

### Description
- Increased `TABLE_RESTITUTION` from `0.77` to `0.89` in `table_tennis_simulation.py` to reduce over-damping of table bounces. 
- Added `RPS = 2 * np.pi` and explanatory comments to `benchmark_direct_services.py` and switched direct-service angular velocities to be expressed as revolutions-per-second times `RPS`. 
- Replaced near-zero `omega` entries with representative high-spin profiles for `pendulum`, `reverse_pendulum`, `hook`, `tomahawk`, `reverse_tomahawk`, and `backhand_standard` (for example `pendulum: (0.0, -45.0 * RPS, -35.0 * RPS)`, `hook: (0.0, -50.0 * RPS, -45.0 * RPS)`, `tomahawk: (50.0 * RPS, -30.0 * RPS, 0.0)`). 
- Kept existing velocity/position/depth parameters unchanged aside from these spin and restitution adjustments. 

### Testing
- Ran `python -m py_compile table_tennis_simulation.py benchmark_direct_services.py benchmark_racket_services.py` and it completed successfully. 
- Executed `python benchmark_direct_services.py --repeat 1` and it produced a CSV benchmark output with `54` rows, confirming the benchmark runs end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ac72ac5c88333950a2f25a6547bc8)